### PR TITLE
i18n: Shortening of a text string

### DIFF
--- a/lang/main_pl.arb
+++ b/lang/main_pl.arb
@@ -1,5 +1,5 @@
 {
-    "autodetect": "Automatyczne wykrywanie",
+    "autodetect": "Autowykrywanie",
     "afrikaans": "afrikaans",
     "albanian": "albański",
     "amharic": "amharski",


### PR DESCRIPTION
Matching the text string to the language selection window.

Screenshot:

![obraz](https://user-images.githubusercontent.com/47037905/133781859-f47f79eb-13d6-497a-afb2-7f31fadeb958.png)

@Aga-C Sorry to correct it, but it is necessary.