### PR TITLE
Fixed inactive buttons after paste/share

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -41,13 +41,15 @@ bool isThereLibreTranslate = false;
 
 const methodChannel = MethodChannel('com.simplytranslate/translate');
 
-Future<void> getSharedText() async {
+Future<void> getSharedText(setState) async {
   print('starting ---------------------------------------------');
   try {
     var answer = await methodChannel.invokeMethod('getText');
     if (answer != '') {
-      translationInput = answer.toString();
-      translationInputController.text = translationInput;
+      setState(() {
+        translationInput = answer.toString();
+        translationInputController.text = translationInput;
+      });
     }
   } on PlatformException catch (e) {
     print(e);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,8 +53,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       print('wewe');
-      getSharedText();
-      setState(() {});
+      getSharedText(setState);
     }
   }
 
@@ -322,7 +321,7 @@ class _MainPageState extends State<MainPage> {
   @override
   void initState() {
     checkLibreTranslate(setState);
-    getSharedText();
+    getSharedText(setState);
     super.initState();
   }
 

--- a/lib/widgets/paste_clipboard_button.dart
+++ b/lib/widgets/paste_clipboard_button.dart
@@ -4,7 +4,9 @@ import '../data.dart';
 
 class PasteClipboardButton extends StatelessWidget {
   final changeText;
+  final setStateParent;
   const PasteClipboardButton({
+    required this.setStateParent,
     this.changeText,
     Key? key,
   }) : super(key: key);
@@ -19,9 +21,14 @@ class PasteClipboardButton extends StatelessWidget {
         onPressed: () {
           Clipboard.getData(Clipboard.kTextPlain).then((value) {
             if (value != null) {
-              translationInputController.text += value.text.toString();
-              translationInputController.selection = TextSelection.collapsed(
-                  offset: translationInputController.text.length);
+              var newText =
+                  translationInputController.text + value.text.toString();
+              var selection = TextSelection.collapsed(offset: newText.length);
+              setStateParent(() {
+                translationInput = newText;
+                translationInputController.text = newText;
+                translationInputController.selection = selection;
+              });
             }
           });
         },

--- a/lib/widgets/translation_input_widget.dart
+++ b/lib/widgets/translation_input_widget.dart
@@ -74,7 +74,7 @@ class _TranslationInputState extends State<TranslationInput> {
                     setStateParent: setState,
                     setStateParentParent: widget.setStateParent),
                 CopyToClipboardButton(translationInput),
-                PasteClipboardButton(),
+                PasteClipboardButton(setStateParent: setState),
               ],
             ),
           )


### PR DESCRIPTION
Hi,

I've fixed the issue with delete and copy buttons being inactive after pasting clipboard contents or after sharing from another app (it was working only if app was in a background; wasn't working if app wasn't turned on).

It wasn't working, because you were editing text directly in a controller without wrapping it in a proper setState. I provided setState as an argument to getSharedText and PasteClipboardButton to make it work. Also, I've removed an empty setState invocation - it's not needed now.