### PR TITLE
i18n: [EN] Add a dot

### DIFF
--- a/lang/main_en.arb
+++ b/lang/main_en.arb
@@ -118,7 +118,7 @@
     "check": "Check",
 
     "something_went_wrong": "Something went wrong",
-    "check_instance": "Check instance",
+    "check_instance": "Check instance.",
     "no_internet": "No internet connection",
     "ok": "OK",
 


### PR DESCRIPTION
There should be a period at the end of the error description.